### PR TITLE
Ordena los comentarios por cuatri descendentemente

### DIFF
--- a/js/results.js
+++ b/js/results.js
@@ -134,12 +134,16 @@ Table = {
       row.score = Calc.score(row);
       return row;
     });
-    const sorted_rows = rows.sort((a,b) => (b.score-a.score));
+    rows.sort((a,b) => (b.score-a.score));
 
     let html_doc = "";
     rows.forEach(function(row){
       if (row.respuestas >0){
       var comments = Results.comentarios.filter(x => (x.doc == row.nombre && x.mat == Equivalency.getEquivalent(materia)));
+
+			// Ordeno comentarios segun cuatrimestre (descendente)
+			comments.sort(sortComentariosPorCuatriDescendente)
+
       const comms = [];
       comments.forEach((item, i) => {
         if(item.comentarios && item.editado == 0){

--- a/js/results_old.js
+++ b/js/results_old.js
@@ -88,18 +88,22 @@ Table = {
     // Populate table
     sorted_rows.forEach(function(row){
       const comm = comments.filter(x => x.doc==row.doc);
-       const comms = [];
-       comm.forEach((item, i) => {
-         if(item.comentarios && item.editado == 0){
-           item.comentarios.forEach((c, j) => {
-             item.comentarios[j] = '(' + item.cuat + ')' + ' - ' + c;
-           });
-           item.editado = 1;
-         }
-         item.comentarios.forEach((c, i) => {
-           comms.push(c);
-         });
-       });
+
+			// Ordeno comentarios segun cuatrimestre (descendente)
+			comm.sort(sortComentariosPorCuatriDescendente)
+
+			const comms = [];
+			comm.forEach((item, i) => {
+				if(item.comentarios && item.editado == 0){
+					item.comentarios.forEach((c, j) => {
+						item.comentarios[j] = '(' + item.cuat + ')' + ' - ' + c;
+					});
+					item.editado = 1;
+				}
+				item.comentarios.forEach((c, i) => {
+					comms.push(c);
+				});
+			});
 
       // Use apropiate users glyphs as row.respuestas grows
       const users_glyph = (row.respuestas<3)?"fas fa-user":

--- a/js/utils.js
+++ b/js/utils.js
@@ -20,6 +20,23 @@ function b64_to_utf8( str ) {
   return res;
 }
 
+const sortComentariosPorCuatriDescendente = (a, b) => {
+	const [cuatriA, anioA] = a.cuat.split("Q")
+	const [cuatriB, anioB] = b.cuat.split("Q")
+	
+	if (anioA > anioB) {
+		return -1
+	} else if (anioA < anioB) {
+		return 1
+	} else {
+		if (cuatriA > cuatriB) {
+			return -1
+		} else {
+			return 1
+		}
+	}
+}
+
 Stats = {
   stats: function(x){
     const mean = x.reduce((sum, value) => sum + value) /x.length;


### PR DESCRIPTION
Ordena los comentarios de manera que queden primero los comentarios de cuatrimestres más nuevos.
Una mejora que se propuso acá #42.